### PR TITLE
Force overwrite executable when there is a dependency conflict

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,6 +32,11 @@
     fluent_gem_executable: /opt/td-agent/bin/fluent-gem
   when: fluentd_version >= 4
 
+- name: Remove rdkafka to prevent conflict with splunk HEC plugin
+  yum:
+    name: rdkafka
+    state: absent
+
 - name: Ensure Fluentd plugins are installed.
   gem:
     name: "{{ item.name | default(item) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,11 +32,6 @@
     fluent_gem_executable: /opt/td-agent/bin/fluent-gem
   when: fluentd_version >= 4
 
-- name: Remove rdkafka to prevent conflict with splunk HEC plugin
-  yum:
-    name: rdkafka
-    state: absent
-
 - name: Ensure Fluentd plugins are installed.
   gem:
     name: "{{ item.name | default(item) }}"
@@ -44,6 +39,7 @@
     state: "{{ item.state | default('present') }}"
     version: "{{ item.version | default(omit) }}"
     user_install: false
+    force: true
   with_items: "{{ fluentd_plugins }}"
 
 - name: Start Fluentd.


### PR DESCRIPTION
Fixes error in Ansible task that installs Fluentd plugin whose dependency contains an executable that conflicts with `rdkafka`.  For example:
```
[root@ip-172-25-96-182 ansible]# /opt/td-agent/bin/fluent-gem install --no-user-install --no-document fluent-plugin-splunk-hec
json-jwt's executable "console" conflicts with rdkafka
Overwrite the executable? [yN]  y
```
will fail when run from the Ansible task because it prompts the user for input. By setting the `force` boolean to `true`, this will bypass that dependency check, allowing the Ansible task to proceed.  See docs for more info: https://docs.ansible.com/ansible/latest/collections/community/general/gem_module.html#parameter-force. 